### PR TITLE
hotfix: lock puppeteer deps & security overrides

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,27 @@
-﻿* text=auto eol=lf
+﻿* text=auto
+
+# Force LF für Code/Config
+*.yml  text eol=lf
+*.yaml text eol=lf
+*.sh   text eol=lf
+*.js   text eol=lf
+*.ts   text eol=lf
+*.tsx  text eol=lf
+*.css  text eol=lf
+*.scss text eol=lf
+*.html text eol=lf
+*.json text eol=lf
+*.md   text eol=lf
+*.toml text eol=lf
+
+# Windows-Skripte
+*.bat  text eol=crlf
+*.ps1  text eol=crlf
+
+# Binärdateien
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.pdf  binary

--- a/apps/frontend/public/_headers
+++ b/apps/frontend/public/_headers
@@ -1,14 +1,5 @@
-/*.js
+﻿/*
   Cache-Control: public, max-age=31536000, immutable
-
-/*.css
-  Cache-Control: public, max-age=31536000, immutable
-
-/*
-  Cache-Control: public, max-age=31536000, immutable
-
-/
-  Cache-Control: no-cache
 
 /index.html
   Cache-Control: no-cache

--- a/apps/frontend/public/_redirects
+++ b/apps/frontend/public/_redirects
@@ -1,1 +1,1 @@
-/*  /index.html  200
+﻿/*  /index.html  200

--- a/ci_heartbeat.txt
+++ b/ci_heartbeat.txt
@@ -1,1 +1,1 @@
-ci_heartbeat: 2025-09-29
+﻿ci_heartbeat: 2025-09-29


### PR DESCRIPTION
Locks ws>=8.17.1, tar-fs>=3.0.9; fixes auto-commit to current branch.