### PR TITLE
Add fallback HTML page for missing build

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,1 @@
+<h1>SF-1 Sammelbecken</h1><p>Kein Build erkannt. Lege index.html oder package.json mit Build an.</p>


### PR DESCRIPTION
## Summary
- add a minimal public/index.html placeholder to indicate that no build artifacts were found

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbc208c0248327b26305ffeac1cf95