### PR TITLE
Restore Netlify Node 20 build environment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,1 +1,30 @@
-﻿
+[build]
+  base = "apps/frontend"
+  command = "npm run build"
+  publish = "build"
+
+[build.environment]
+  NODE_VERSION = "20"
+  NPM_FLAGS = "--legacy-peer-deps"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+
+# HTML niemals cachen (Regeln zuerst!)
+[[headers]]
+  for = "/"
+  [headers.values]
+    Cache-Control = "no-cache"
+
+[[headers]]
+  for = "/index.html"
+  [headers.values]
+    Cache-Control = "no-cache"
+
+# Statische Assets aggressiv cachen
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"


### PR DESCRIPTION
## Summary
- restore the Netlify build environment configuration so deploys continue using Node 20 with the required npm flags
- keep the explicit no-cache headers for HTML while leaving asset caching untouched

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbc53f2b9c832780e22e07de11f9c0